### PR TITLE
Change include to include local file instead of installed library

### DIFF
--- a/I2CSoilMoistureSensor.cpp
+++ b/I2CSoilMoistureSensor.cpp
@@ -9,7 +9,7 @@
  * MIT license                                                          *
  *----------------------------------------------------------------------*/ 
 
-#include <I2CSoilMoistureSensor.h>
+#include "I2CSoilMoistureSensor.h"
 
 //define release-independent I2C functions
 #if defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)


### PR DESCRIPTION
I've changed to include to include the local I2CSoilMoistureSensor.h instead of the installed library. This makes the files more compatible in case someone wants to just include them in a folder and not install the library in arduino itself.
